### PR TITLE
fix:args parameters didn't pass to AnyGPTInference correctly

### DIFF
--- a/anygpt/src/infer/cli_infer_chat_model.py
+++ b/anygpt/src/infer/cli_infer_chat_model.py
@@ -420,6 +420,8 @@ if __name__=='__main__':
         args.model_name_or_path,
         args.image_tokenizer_path,
         args.output_dir,
+        speech_tokenizer_config=args.speech_tokenizer_config,
+        speech_tokenizer_path=args.speech_tokenizer_path,
         soundstorm_path=args.soundstorm_path
     )
 


### PR DESCRIPTION
AnyGPT\anygpt\src\infer\cli_infer_chat_model.py中的命令行参数没有被完整传入AnyGPTInference函数中